### PR TITLE
essentials: talk about ||-identifiers

### DIFF
--- a/koans/essentials.rkt
+++ b/koans/essentials.rkt
@@ -8,9 +8,13 @@
 (define foo 3)
 (check-equal? foo "?")
 
-; Racket only prohibits ()[]{}",'`;#|\ characters in identifiers.
+; Racket only prohibits ()[]{}",'`;#|\ characters in identifiers ...
 (define 2&--????++ "This identifier is okay.")
 (check-equal? 2&--????++ "Yeah, really.")
+
+; ... unless the identifier is surrounded in pipes. Then, anything goes.
+(define |()[]{}",'`;#|\| "This identifier is okay too")
+(check-equal? |()[]{}",'`;#|\| "The empty identifier is ||")
 
 ; Whitespace between meaningful tokens are ignored, but be sure to use
 ; common sense and consistent indentation.


### PR DESCRIPTION
The guide doesn't talk about how ANY symbol can be used as an identifier
if its enclosed in pipes (|), but I think that's worth saying in the
koans.

I thought about adding something like `(string->symbol "hello world")`
but decided against it