### PR TITLE
Remove distractions from making tests pass 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ commands are available to your shell.
 
 Read `koans/all.rkt` to see suggested reading order.
 
-To practice, open a topic file and make all tests pass. `"?"` will
-mark where you are expected to write an answer. Other times
-tests will be written with intentionally incorrect code.
+To practice, open a topic file and make all tests pass.
+Intentionally places `?` characters will mark where you
+are expected to write an answer. Other times tests will
+be written with intentionally incorrect code.
 
 
 ## Contributing

--- a/koans/essentials.rkt
+++ b/koans/essentials.rkt
@@ -67,4 +67,4 @@
 ;; Racket allows you to switch up bracket styles freely using
 ;; {}, [] or () pairs, but this should only be done to respect
 ;; conventions that make code more legibile.
-[check-equal? {add-two-numbers 99 1} (* 10 "?")]
+[check-equal? {add-two-numbers 99 1} (* 10 10)]

--- a/koans/io.rkt
+++ b/koans/io.rkt
@@ -2,8 +2,11 @@
 
 (require rackunit)
 
+
 ;; Create a path to data/1thru10.
 (define path-to-1thru10 "?")
 
 ;; Using your new path, write an expression that sums the integers in data/1thru10.
-(check-eqv? (call-with-input-file path-to-1thru10 "?" 55)
+(if (path? path-to-1thru10)
+  (check-eqv? (call-with-input-file path-to-1thru10 "?") 55)
+  (fail "Define a path"))

--- a/koans/lists.rkt
+++ b/koans/lists.rkt
@@ -7,9 +7,11 @@
 
 ;; Make a pair matching expectations.
 (define pair "?")
-(check-pred pair? pair)
-(check-equal? (car pair) "first")
-(check-equal? (car (cdr pair)) "second")
+(if (pair? pair)
+  (begin
+    (check-equal? (car pair) "first")
+    (check-equal? (car (cdr pair)) "second"))
+  (fail "Define a pair"))
 
 ;; Make a list of the first 1000 positive integers. Do not type it longhand.
 (define thousand "?")
@@ -21,16 +23,19 @@
       (counter-matches-element (cdr lst) (add1 i))
       i)))
 
-(check-eqv?
-  (counter-matches-element thousand 1)
-  1001)
-
+(if (list? thousand)
+  (check-eqv?
+    (counter-matches-element thousand 1)
+    1001)
+  (fail "Define `thousand` as a list"))
 
 ;; Transform `thousand` into 'only-punc', which is a list of
 ;; characters such that every element matches char-punctuation?
 (define only-punc "?")
-(check-true
-  (and
-    (foldl (lambda (e r) (and e r)) #t
-      (map char-punctuation? only-punc))
-    (eqv? (length only-punc) 32)))
+(if (list? thousand)
+  (check-true
+    (and
+      (foldl (lambda (e r) (and e r)) #t
+        (map char-punctuation? only-punc))
+      (eqv? (length only-punc) 32)))
+  (fail "Define `only-punc` as a list"))

--- a/koans/modules.rkt
+++ b/koans/modules.rkt
@@ -1,6 +1,8 @@
 #lang racket/base
 
-(require rackunit)
+(require
+  rackunit
+  syntax/macro-testing)
 
 
 ;;; All .rkt files you have seen are modules and the instructions within
@@ -10,8 +12,12 @@
 ;;; https://docs.racket-lang.org/guide/Module_Syntax.html
 
 
-(module "?" "?" "?")
+(module meta racket (define (submod-fn) "?"))
 (require 'meta)
-(check-equal?
-  (submod-fn)
-  "From the submodule")
+
+(check-not-exn (lambda ()
+  (convert-compile-time-error
+    (check-equal?
+      (submod-fn)
+      "From the submodule")))
+  "Did you provide the submodule function?")

--- a/koans/numbers.rkt
+++ b/koans/numbers.rkt
@@ -31,25 +31,22 @@
 
 
 ;; More equality predicates will also start appearing in tests.
-;; To shake things up, from now on all tests may intentionally
-;; use the wrong predicate. Remember that if your solution looks
-;; right but your tests keep failing.
-;;
 ;; See https://docs.racket-lang.org/rackunit/api.html#%28part._.Checks%29
 (check-not-eqv? 3 3.0)
 
 ;; Using only 'exact?' and 'inexact?', categorize these numbers.
-(check-pred "?" #i0)
-(check-pred "?" -1)
-(check-pred "?" 1)
-(check-pred "?" #i#b100)
-(check-pred "?" 999999999999999)
-(check-pred "?" 2/3)
-(check-pred "?" #e2/3)
-(check-pred "?" #i0)
-(check-pred "?" 1/2+8/9i)
-(check-pred "?" 0.1)
-(check-pred "?" (34 * 0.1))
-(check-pred "?" #e.23e+42)
-(check-pred "?" -inf.0)
-(check-pred "?" +nan.0)
+(define (replaceme x) #f)
+(check-pred replaceme #i0)
+(check-pred replaceme -1)
+(check-pred replaceme 1)
+(check-pred replaceme #i#b100)
+(check-pred replaceme 999999999999999)
+(check-pred replaceme 2/3)
+(check-pred replaceme #e2/3)
+(check-pred replaceme #i0)
+(check-pred replaceme 1/2+8/9i)
+(check-pred replaceme 0.1)
+(check-pred replaceme (* 34 0.1))
+(check-pred replaceme #e.23e+42)
+(check-pred replaceme -inf.0)
+(check-pred replaceme +nan.0)

--- a/koans/procedures.rkt
+++ b/koans/procedures.rkt
@@ -73,12 +73,18 @@
 ;; need 'case->'
 (define (my-join) "?")
 
-;; Keep these checks as is.
-(check-equal? (my-join #\- 1 2 3) "1-2-3")
-(check-equal? (my-join #\space 1 2 3) "1 2 3")
-(check-equal? (my-join 1 2 3) "1 2 3")
-(check-equal? (my-join #\space 1) "1")
-(check-equal? (my-join 1) "1")
-(check-exn (λ () (my-join ",")))
-(check-exn (λ () (my-join #\space "a" "b")))
-(check-exn (λ () (my-join "," 0.1 9)))
+(let ([arity (procedure-arity my-join)])
+  (if
+    (and
+      (arity-at-least? arity)
+      (eqv? arity-at-least-value 1))
+    (begin
+       (check-equal? (my-join #\- 1 2 3) "1-2-3")
+       (check-equal? (my-join #\space 1 2 3) "1 2 3")
+       (check-equal? (my-join 1 2 3) "1 2 3")
+       (check-equal? (my-join #\space 1) "1")
+       (check-equal? (my-join 1) "1")
+       (check-exn (λ () (my-join ",")))
+       (check-exn (λ () (my-join #\space "a" "b")))
+       (check-exn (λ () (my-join "," 0.1 9))))
+    (fail "Double check your signature of my-join")))

--- a/koans/structs.rkt
+++ b/koans/structs.rkt
@@ -1,13 +1,19 @@
 #lang racket/base
 
-(require rackunit)
+(require
+  rackunit
+  syntax/macro-testing)
 
 
-;; Produce a single struct that passes all assertions.
-(let ([p "?"])
-  (check-pred racketeer? p)
-  (check-pred programmer? p)
-  (check-pred struct? p)
-  (check-pred procedure? set-programmer-salary!)
-  (check-equal? (programmer-confusion-level p) 10)
-  (check-equal? (racketeer-desire-for-racket-jobs p) 9001))
+(check-not-exn (lambda () ; Make a struct instance to pass these tests.
+  (convert-compile-time-error (let ([p "?"])
+    (check-pred racketeer? p)
+    (check-pred programmer? p)
+    (check-pred struct? p)
+    (check-pred procedure? set-programmer-salary!)
+    (check-equal? (programmer-confusion-level p) 10)
+    (check-equal? (racketeer-desire-for-racket-jobs p) 9001))))
+  (string-append
+    "The struct definition seems wrong. At least one the symbols "
+    "Racket creates for the needed struct is not present, or some "
+    "other exception was thrown."))

--- a/koans/syntax.rkt
+++ b/koans/syntax.rkt
@@ -2,7 +2,8 @@
 
 (require
   rackunit
-  (for-syntax racket/base syntax/parse))
+  (for-syntax racket/base syntax/parse)
+  syntax/macro-testing)
 
 
 ;; `syntax` creates a syntax object
@@ -65,8 +66,10 @@
      (define num-args (length args-list))
      #`#,num-args]))
 
-(check-equal? (count-args2 'A) "there is an error in the definition of `count-args2`")
-(check-equal? (count-args2 a b c d) 4)
+(check-not-exn (lambda ()
+  (convert-compile-time-error (let ()
+    (check-equal? (count-args2 'A) "there is an error in the definition of `count-args2`")
+    (check-equal? (count-args2 a b c d) 4)))))
 
 ;; `syntax-parse` is helpful for writing macros, and macros are helpful for
 ;; programming your programs.


### PR DESCRIPTION
#20 

As of this commit, when you clone the repository all tests will show
failures when you run `racket/all.rkt` as per koan conventions.

I had been running on the assumption that code that won't compile
had pedagogical value, but I had been checking in incorrect code in
spots where I expected the user to find it. This turned out to be
a really distracting experience that gives mixed messaging re:
reading order (`racket koans/all.rkt` would crash in a spot
somewhere in the middle of the reading order).

There's still value in signaling code that will not compile,
but that should be called out explicitly using a future
language that treats user submissions as data, instead of
assuming the code tracked in this repository and the user's
submissions are one and the same.

Side note: I also removed messaging to suggest that the user should expect
some tests to be incorrectly written as intentional "gotchas." Another distraction,
and bad form in the end.

Now, when you clone the repo, all test topics just return rackunit failures.
No compile-time errors that interrupt the flow.