### PR TITLE
Fix an arity check, add explicit predicates for check-exn

### DIFF
--- a/koans/procedures.rkt
+++ b/koans/procedures.rkt
@@ -77,15 +77,15 @@
   (if
     (and
       (arity-at-least? arity)
-      (eqv? arity-at-least-value 1))
+      (eqv? (arity-at-least-value arity) 1))
     (begin
        (check-equal? (my-join #\- 1 2 3) "1-2-3")
        (check-equal? (my-join #\space 1 2 3) "1 2 3")
        (check-equal? (my-join 1 2 3) "1 2 3")
        (check-equal? (my-join #\space 1) "1")
        (check-equal? (my-join 1) "1")
-       (check-exn (λ () (my-join #\?)))
-       (check-exn (λ () (my-join ",")))
-       (check-exn (λ () (my-join #\space "a" "b")))
-       (check-exn (λ () (my-join "," 0.1 9))))
+       (check-exn exn:fail? (λ () (my-join #\?)))
+       (check-exn exn:fail? (λ () (my-join ",")))
+       (check-exn exn:fail? (λ () (my-join #\space "a" "b")))
+       (check-exn exn:fail? (λ () (my-join "," 0.1 9))))
     (fail "Double check your signature of my-join")))


### PR DESCRIPTION
Now `check-exn` as far as I can see requires an explicit exception predicate ([doc](https://docs.racket-lang.org/rackunit/api.html?q=check-exn#%28def._%28%28lib._rackunit%2Fmain..rkt%29._check-exn%29%29)).

Also I fixed an arity check: it was comparing `arity-at-least-value` procedure with a number.